### PR TITLE
Feature/update remove

### DIFF
--- a/bin/db/datastore/cursor/count.ts
+++ b/bin/db/datastore/cursor/count.ts
@@ -1,6 +1,7 @@
 import * as chalk from 'chalk';
 
 export function _Count(){
+
   this.cursor.exec(function ( err:Error, docs:{}[] ) {
     if(err){
       console.log(chalk.red(`${err}, \n An error occurred during the count cursor function`));

--- a/bin/db/datastore/findOne/findOne.ts
+++ b/bin/db/datastore/findOne/findOne.ts
@@ -1,4 +1,4 @@
-// db.datastore.findOne(query)  =  mongo db.collection.findOne(query)
+
 import * as chalk from 'chalk';
 
 const findOneCB = function (err:Error, doc:string):void {

--- a/bin/db/datastore/index.ts
+++ b/bin/db/datastore/index.ts
@@ -4,4 +4,4 @@ export { Cursor } from './cursor';
 export { printFind } from './find';
 export { printFindOne } from './findOne';
 export { noPrintInsert, printInsert} from './insert';
-export { updateDocs } from './update';
+export { updateDocs, updateManyDocs } from './update';

--- a/bin/db/datastore/index.ts
+++ b/bin/db/datastore/index.ts
@@ -1,1 +1,7 @@
 export { Store } from './store';
+export { printCount } from './count';
+export { Cursor } from './cursor';
+export { printFind } from './find';
+export { printFindOne } from './findOne';
+export { noPrintInsert, printInsert} from './insert';
+export { updateDocs } from './update';

--- a/bin/db/datastore/index.ts
+++ b/bin/db/datastore/index.ts
@@ -5,3 +5,4 @@ export { printFind } from './find';
 export { printFindOne } from './findOne';
 export { noPrintInsert, printInsert} from './insert';
 export { updateDocs, updateManyDocs } from './update';
+export { removeDocs } from './remove';

--- a/bin/db/datastore/remove/index.ts
+++ b/bin/db/datastore/remove/index.ts
@@ -1,1 +1,1 @@
-// db.datastore.remove(query)  =  mongo db.collection.remove(query)
+export { removeDocs } from './remove';

--- a/bin/db/datastore/remove/interfaces.ts
+++ b/bin/db/datastore/remove/interfaces.ts
@@ -1,0 +1,7 @@
+export interface queryOptionsInterface{
+  multi?: boolean;
+}
+
+export interface returnObj{
+  removed:number;
+}

--- a/bin/db/datastore/remove/remove.ts
+++ b/bin/db/datastore/remove/remove.ts
@@ -1,0 +1,15 @@
+
+import * as chalk from 'chalk';
+import { queryOptionsInterface, returnObj} from './interfaces';
+
+const removeCB = function ( err:Error, numRemoved:number) {
+  if(err) console.log(chalk.red(`${err}: \n An error occurred during Update`));
+  const returnObj:returnObj = {removed: 0};
+  returnObj.removed = numRemoved;
+  console.log(returnObj);
+};
+
+export function removeDocs(query: {}, queryOptions: queryOptionsInterface,cb?:any ){
+  if(!queryOptions) queryOptions = {};
+  this.remove(query, queryOptions, (cb?cb:removeCB));
+}

--- a/bin/db/datastore/store.ts
+++ b/bin/db/datastore/store.ts
@@ -4,10 +4,11 @@ import { DataStore } from '../interfaces';
 import NeDB = NeDBDataStore;
 import * as NeDBDataStore from "nedb";
 
-import { printInsert , noPrintInsert } from './insert';
-import { printFind } from './find';
-import { printFindOne } from './findOne';
-import { printCount } from './count';
+import {
+  printInsert, noPrintInsert,
+  printFindOne, printFind, printCount,
+  updateDocs
+} from '../datastore';
 
 export class Store extends NeDBDataStore{
   constructor(query: DataStore){
@@ -29,6 +30,8 @@ export class Store extends NeDBDataStore{
   FindOne = printFindOne;
 
   Find = printFind;
+
+  Update = updateDocs;
 
   Count = printCount;
 }

--- a/bin/db/datastore/store.ts
+++ b/bin/db/datastore/store.ts
@@ -7,7 +7,7 @@ import * as NeDBDataStore from "nedb";
 import {
   printInsert, noPrintInsert,
   printFindOne, printFind, printCount,
-  updateDocs
+  updateDocs, updateManyDocs
 } from '../datastore';
 
 export class Store extends NeDBDataStore{
@@ -32,6 +32,7 @@ export class Store extends NeDBDataStore{
   Find = printFind;
 
   Update = updateDocs;
+  UpdateMany = updateManyDocs;
 
   Count = printCount;
 }

--- a/bin/db/datastore/store.ts
+++ b/bin/db/datastore/store.ts
@@ -7,7 +7,7 @@ import * as NeDBDataStore from "nedb";
 import {
   printInsert, noPrintInsert,
   printFindOne, printFind, printCount,
-  updateDocs, updateManyDocs
+  updateDocs, updateManyDocs, removeDocs
 } from '../datastore';
 
 export class Store extends NeDBDataStore{
@@ -17,7 +17,7 @@ export class Store extends NeDBDataStore{
       inMemoryOnly: query.inMemoryOnly,
       autoload: query.autoload,
       onload: query.onload,
-     // nodeWebkitAppName: query.nodeWebkitAppName, jack wagon can make a types file
+
       afterSerialization: query.afterSerialization,
       beforeDeserialization: query.beforeDeserialization,
       corruptAlertThreshold: query.corruptAlertThreshold
@@ -33,6 +33,8 @@ export class Store extends NeDBDataStore{
 
   Update = updateDocs;
   UpdateMany = updateManyDocs;
+
+  Remove = removeDocs;
 
   Count = printCount;
 }

--- a/bin/db/datastore/update/autoReply.ts
+++ b/bin/db/datastore/update/autoReply.ts
@@ -1,0 +1,27 @@
+import * as chalk from 'chalk';
+import { replyInterface, upsertedDocument } from './interfaces';
+
+export function autoReply( err:Error, numAffected:number, affectedDocuments?:upsertedDocument, upsert?:boolean ) {
+  let replyObject:replyInterface = {};
+  if(err) console.log(chalk.red(`${err}: \n An error occurred during Update`));
+
+  if(upsert){
+    replyObject.changed = numAffected;
+    replyObject.affectedDocument = (affectedDocuments)? affectedDocuments : 0;
+    replyObject.upsert = upsert;
+  } else if(!upsert){
+    replyObject.changed = numAffected;
+    replyObject.affectedDocument = {};
+    replyObject.affectedDocuments = [];
+    if(Array.isArray(affectedDocuments)){
+      affectedDocuments.forEach(function(doc:upsertedDocument){
+        replyObject.affectedDocuments.push(doc._id);
+      });
+    } else if(affectedDocuments){
+      replyObject.affectedDocument = affectedDocuments._id;
+    }
+    replyObject.upsert = false;
+  }
+
+  console.log(replyObject);
+};

--- a/bin/db/datastore/update/index.ts
+++ b/bin/db/datastore/update/index.ts
@@ -1,1 +1,1 @@
-// db.datastore.update(query) = mongo db.collection.update(query)
+export { updateDocs } from './update';

--- a/bin/db/datastore/update/index.ts
+++ b/bin/db/datastore/update/index.ts
@@ -1,1 +1,2 @@
 export { updateDocs } from './update';
+export { updateManyDocs } from './updateMany';

--- a/bin/db/datastore/update/interfaces.ts
+++ b/bin/db/datastore/update/interfaces.ts
@@ -1,0 +1,16 @@
+export interface replyInterface{
+  changed?:number;
+  affectedDocument?:upsertedDocument;
+  affectedDocuments?:upsertedDocument[];
+  upsert?:boolean;
+}
+
+export interface updateOptionsInterface{
+  multi?:boolean;
+  upsert?:boolean;
+  returnUpdateDocs?:boolean;
+}
+
+export interface upsertedDocument{
+  _id?:string;
+}

--- a/bin/db/datastore/update/update.ts
+++ b/bin/db/datastore/update/update.ts
@@ -1,0 +1,30 @@
+
+import * as chalk from 'chalk';
+
+interface replyInterface{
+  changed?:number;
+  affectedDocument?:{}|{}[];
+  upsert?:boolean;
+}
+
+const autoReply = function ( err:Error, numAffected:number, affectedDocuments?:{}|{}[], upsert?:boolean ) {
+  let replyObject:replyInterface = {};
+  if(err) console.log(chalk.red(`${err}: \n An error occurred during Update`));
+
+  if(upsert){
+    replyObject.changed = numAffected;
+    replyObject.affectedDocument = (affectedDocuments)? affectedDocuments : 0;
+    replyObject.upsert = upsert;
+  } else if(!upsert){
+    replyObject.changed = numAffected;
+    replyObject.affectedDocument = [];
+    replyObject.upsert = false;
+  }
+
+  console.log(replyObject);
+};
+
+export function updateDocs(query: {}, updateQuery:{}, updateOptions?:{},cb?:any ){
+  if(!updateOptions) updateOptions = {};
+  this.update(query,updateQuery,updateOptions,(cb?cb:autoReply));
+}

--- a/bin/db/datastore/update/update.ts
+++ b/bin/db/datastore/update/update.ts
@@ -1,25 +1,6 @@
 
-import * as chalk from 'chalk';
-import { replyInterface, updateOptionsInterface, upsertedDocument } from './interfaces';
-
-const autoReply = function ( err:Error, numAffected:number, affectedDocuments?:upsertedDocument, upsert?:boolean ) {
-  let replyObject:replyInterface = {};
-  if(err) console.log(chalk.red(`${err}: \n An error occurred during Update`));
-
-  if(upsert){
-    replyObject.changed = numAffected;
-    replyObject.affectedDocument = (affectedDocuments)? affectedDocuments : 0;
-    replyObject.upsert = upsert;
-  } else if(!upsert){
-    replyObject.changed = numAffected;
-    if(affectedDocuments){
-      replyObject.affectedDocument = affectedDocuments._id;
-    }
-    replyObject.upsert = false;
-  }
-
-  console.log(replyObject);
-};
+import { updateOptionsInterface} from './interfaces';
+import { autoReply } from './autoReply';
 
 export function updateDocs(query: {}, updateQuery:{}, updateOptions?:updateOptionsInterface,cb?:any ){
   if(!updateOptions) updateOptions = {};

--- a/bin/db/datastore/update/update.ts
+++ b/bin/db/datastore/update/update.ts
@@ -1,13 +1,8 @@
 
 import * as chalk from 'chalk';
+import { replyInterface, updateOptionsInterface, upsertedDocument } from './interfaces';
 
-interface replyInterface{
-  changed?:number;
-  affectedDocument?:{}|{}[];
-  upsert?:boolean;
-}
-
-const autoReply = function ( err:Error, numAffected:number, affectedDocuments?:{}|{}[], upsert?:boolean ) {
+const autoReply = function ( err:Error, numAffected:number, affectedDocuments?:upsertedDocument, upsert?:boolean ) {
   let replyObject:replyInterface = {};
   if(err) console.log(chalk.red(`${err}: \n An error occurred during Update`));
 
@@ -17,14 +12,16 @@ const autoReply = function ( err:Error, numAffected:number, affectedDocuments?:{
     replyObject.upsert = upsert;
   } else if(!upsert){
     replyObject.changed = numAffected;
-    replyObject.affectedDocument = [];
+    if(affectedDocuments){
+      replyObject.affectedDocument = affectedDocuments._id;
+    }
     replyObject.upsert = false;
   }
 
   console.log(replyObject);
 };
 
-export function updateDocs(query: {}, updateQuery:{}, updateOptions?:{},cb?:any ){
+export function updateDocs(query: {}, updateQuery:{}, updateOptions?:updateOptionsInterface,cb?:any ){
   if(!updateOptions) updateOptions = {};
   this.update(query,updateQuery,updateOptions,(cb?cb:autoReply));
 }

--- a/bin/db/datastore/update/updateMany.ts
+++ b/bin/db/datastore/update/updateMany.ts
@@ -1,30 +1,6 @@
 import * as chalk from 'chalk';
-import { replyInterface, updateOptionsInterface, upsertedDocument } from './interfaces';
-
-const autoReply = function ( err:Error, numAffected:number, affectedDocuments?:any, upsert?:boolean ) {
-  let replyObject:replyInterface = {};
-  if(err) console.log(chalk.red(`${err}: \n An error occurred during Update`));
-
-  if(upsert){
-    replyObject.changed = numAffected;
-    replyObject.affectedDocument = (affectedDocuments)? affectedDocuments : 0;
-    replyObject.upsert = upsert;
-  } else if(!upsert){
-    replyObject.changed = numAffected;
-    replyObject.affectedDocument = {};
-    replyObject.affectedDocuments = [];
-    if(Array.isArray(affectedDocuments)){
-      affectedDocuments.forEach(function(doc:upsertedDocument){
-        replyObject.affectedDocuments.push(doc._id);
-      });
-    } else if(affectedDocuments){
-      replyObject.affectedDocument = affectedDocuments._id;
-    }
-    replyObject.upsert = false;
-  }
-
-  console.log(replyObject);
-};
+import { autoReply } from './autoReply';
+import { updateOptionsInterface} from './interfaces';
 
 export function updateManyDocs(query: {}, updateQuery:{}, updateOptions?:updateOptionsInterface,cb?:any ){
   if(!updateOptions) updateOptions = {multi: true};

--- a/bin/db/datastore/update/updateMany.ts
+++ b/bin/db/datastore/update/updateMany.ts
@@ -13,7 +13,7 @@ const autoReply = function ( err:Error, numAffected:number, affectedDocuments?:a
     replyObject.changed = numAffected;
     replyObject.affectedDocument = {};
     replyObject.affectedDocuments = [];
-    if(affectedDocuments.length > 1){
+    if(Array.isArray(affectedDocuments)){
       affectedDocuments.forEach(function(doc:upsertedDocument){
         replyObject.affectedDocuments.push(doc._id);
       });

--- a/bin/db/datastore/update/updateMany.ts
+++ b/bin/db/datastore/update/updateMany.ts
@@ -1,0 +1,46 @@
+import * as chalk from 'chalk';
+import { replyInterface, updateOptionsInterface, upsertedDocument } from './interfaces';
+
+const autoReply = function ( err:Error, numAffected:number, affectedDocuments?:any, upsert?:boolean ) {
+  let replyObject:replyInterface = {};
+  if(err) console.log(chalk.red(`${err}: \n An error occurred during Update`));
+
+  if(upsert){
+    replyObject.changed = numAffected;
+    replyObject.affectedDocument = (affectedDocuments)? affectedDocuments : 0;
+    replyObject.upsert = upsert;
+  } else if(!upsert){
+    replyObject.changed = numAffected;
+    replyObject.affectedDocument = {};
+    replyObject.affectedDocuments = [];
+    if(affectedDocuments.length > 1){
+      affectedDocuments.forEach(function(doc:upsertedDocument){
+        replyObject.affectedDocuments.push(doc._id);
+      });
+    } else if(affectedDocuments){
+      replyObject.affectedDocument = affectedDocuments._id;
+    }
+    replyObject.upsert = false;
+  }
+
+  console.log(replyObject);
+};
+
+export function updateManyDocs(query: {}, updateQuery:{}, updateOptions?:updateOptionsInterface,cb?:any ){
+  if(!updateOptions) updateOptions = {multi: true};
+
+  if((updateOptions.hasOwnProperty('returnUpdatedDocs') ||
+    updateOptions.hasOwnProperty('upsert')) &&
+    !updateOptions.hasOwnProperty('multi')) {
+    updateOptions.multi = true;
+  }
+
+  if(updateOptions.multi === false &&
+    (updateOptions.hasOwnProperty('returnUpdatedDocs') ||
+    updateOptions.hasOwnProperty('upsert') ||
+    updateOptions.hasOwnProperty('multi'))){
+    console.log(chalk.red(`You cannot set multi = false with UpdateMany(), please use Update() if you wish to only update one document`));
+  } else {
+    this.update(query,updateQuery,updateOptions,(cb?cb:autoReply));
+  }
+}


### PR DESCRIPTION
__Change Log:__
=

* Update added to datastore
    * db.[name].Update(query:{},updateQuery:{},updateOptions?:{},cb?:function)
    * If you leave the cb blank it will automatically call the autoReply function that returns an object string with information on the update.
    * If you set returnUpdatedDocs:true in the updateOptions you will see the _id of the updated doc
    * If you set returnUpdatedDocs and multi to true. You will receive an array of _ids
* UpdateMany added to datastore
    * db.[name].UpdateMany(query:{},updateQuery:{},updateOptions?:{},cb?:function)
    * UpdateMany also uses a auto reply function.
    * Same rules for returnUpdateDocs. Although multi is auto set to true
    * If you try to set multi to false you will receive a warning.
* Remove Added
    * db.[name].Remove(query:{}, removeOptions:{},cb?:function)
    * Only one options param and that is multi
    * returns the number of removed items
